### PR TITLE
feat: improve random NFT functionality

### DIFF
--- a/components/nft-sale-widget/layout/nft-sale/mint-section.tsx
+++ b/components/nft-sale-widget/layout/nft-sale/mint-section.tsx
@@ -15,6 +15,7 @@ import { getAddresses } from "@/lib/server-utils";
 import usePrivateSale from "@/hooks/usePrivateSale";
 import { useAccount } from "wagmi";
 import ConnectWalletModal from "../../commons/connect-wallet-modal";
+import getAvailableTokenIds from "@/utils/getAvailableTokenIds";
 
 interface MintSectionProps {
   isRandom: boolean;
@@ -66,7 +67,7 @@ const MintSection = ({
         variables: { id: concatenatedId },
         fetchPolicy: "network-only"
       });
-      console.log(data.userCopyBalance, "copyBalance");
+      // console.log(data.userCopyBalance, "copyBalance");
       return data.userCopyBalance;
     } catch (error) {
       console.error("Error fetching user balance:", error);
@@ -98,7 +99,7 @@ const MintSection = ({
           {} as { [key: string]: string }
         );
         setBalances(balancesMap);
-        console.log("Updated balances:", balancesMap);
+        // console.log("Updated balances:", balancesMap);
       } catch (error) {
         console.error("Error fetching user balances:", error);
       }
@@ -131,7 +132,8 @@ const MintSection = ({
 
   const activeTokens = useMemo(() => {
     if (!activeSale) return [];
-    return activeSale.tokensOnSale.map((token, index) => ({
+    const availableTokens = getAvailableTokenIds(activeSale, isOriginal);
+    return availableTokens.map((token, index) => ({
       src: images[index] ?? "",
       price: `${formatUnits(BigInt(activeSale.floorPrice), 18)}`,
       isSold: false,
@@ -206,6 +208,7 @@ const MintSection = ({
             loading={loading}
             refetchBalances={refetchAllBalances}
             handleModal={handleModal}
+            soldOut={activeTokens.length === 0}
           />
         </Flex>
       ) : (

--- a/components/nft-sale-widget/psyc-item.tsx
+++ b/components/nft-sale-widget/psyc-item.tsx
@@ -22,6 +22,7 @@ interface PsycItemProps {
   loading: boolean;
   refetchBalances: () => void;
   handleModal: () => void;
+  soldOut?: boolean;
 }
 
 const PsycItem = ({
@@ -32,7 +33,8 @@ const PsycItem = ({
   isOriginal,
   // loading
   refetchBalances,
-  handleModal
+  handleModal,
+  soldOut
 }: PsycItemProps) => {
   const { buyNft, isPending, isConfirming, isMinting } = useBuyNft(
     isPrivateSale,
@@ -72,7 +74,12 @@ const PsycItem = ({
   const isButtonDisabled =
     isOriginal && !isRandom && isSold
       ? true
-      : isPending || isConfirming || isMinting || isSoldLoading || isPaused;
+      : isPending ||
+        isConfirming ||
+        isMinting ||
+        isSoldLoading ||
+        isPaused ||
+        (isRandom && soldOut);
 
   const modalNeeded = !address || (!isWhitelisted && isOriginal);
 
@@ -106,6 +113,24 @@ const PsycItem = ({
           fill
           objectFit="cover"
         />
+        {soldOut && isRandom && isOriginal && (
+          <Box
+            position="absolute"
+            top="0"
+            left="0"
+            width="100%"
+            height="100%"
+            bg={"#00000026"}
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            backdropFilter={"blur(2px)"}
+          >
+            <Text color="white" fontWeight="bold">
+              Sold Out
+            </Text>
+          </Box>
+        )}
         {isOriginal && isSold && !isRandom && (
           <Box
             position="absolute"
@@ -131,6 +156,7 @@ const PsycItem = ({
           <MintButton
             customStyle={{
               width: "100%",
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               opacity: isButtonDisabled || modalNeeded ? 0.5 : 1,
               cursor: modalNeeded ? "help" : "default"
             }}
@@ -145,6 +171,8 @@ const PsycItem = ({
               </>
             ) : isPaused ? (
               "Paused"
+            ) : soldOut ? (
+              "Sold Out"
             ) : (
               "Mint"
             )}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,6 @@
 import type { Address } from "viem";
 
-interface TokenOnSale {
+export interface TokenOnSale {
   id: string;
   tokenID: string;
   buyer: Address | null;

--- a/services/graph.ts
+++ b/services/graph.ts
@@ -47,6 +47,7 @@ export const getSaleById = gql`
       tokensOnSale {
         id
         tokenID
+        buyer
       }
     }
   }

--- a/utils/getAvailableTokenIds.tsx
+++ b/utils/getAvailableTokenIds.tsx
@@ -1,0 +1,21 @@
+import type { Sale, TokenOnSale } from "@/lib/types";
+
+const getAvailableTokens = (
+  currentSale: Sale | undefined,
+  privateSale: boolean
+) => {
+  let availableNFTs: TokenOnSale[] = [];
+  if (currentSale && privateSale) {
+    availableNFTs = currentSale.tokensOnSale.filter(
+      (item) => item.buyer === null
+    );
+  } else if (currentSale && !privateSale) {
+    availableNFTs = currentSale.tokensOnSale;
+  } else {
+    return [];
+  }
+
+  return availableNFTs;
+};
+
+export default getAvailableTokens;


### PR DESCRIPTION
Work done:

Add sold out state for completed sales
Iterate only through available tokens (i.e., all tokens for copy sale and for original sale, only tokens that haven't been bought)