### PR TITLE
feat: add wrong network state

### DIFF
--- a/components/commons/wrong-network.tsx
+++ b/components/commons/wrong-network.tsx
@@ -1,0 +1,54 @@
+import { Flex, Text, Image } from "@chakra-ui/react";
+import SubmitButtonContainer from "./submit-button-container";
+import PsyButton from "../ui/psy-button";
+import { useChainModal } from "@rainbow-me/rainbowkit";
+
+const WrongNetworkWindow = () => {
+  const { openChainModal } = useChainModal();
+  const CHAINID = Number(process.env.NEXT_PUBLIC_CHAIN_ID) ?? 1;
+  return (
+    <Flex p={2} pb={5} direction={"column"} gap={4}>
+      <Text
+        textColor="#269200"
+        fontWeight="500"
+        fontStyle="italic"
+        mt="1"
+        fontSize={{ base: "20px", sm: "36px" }}
+        fontFamily={"Amiri"}
+      >
+        Wrong network!
+      </Text>
+      <Text
+        textColor="#269200"
+        fontWeight="500"
+        fontStyle="italic"
+        mt="1"
+        fontSize={{ base: "14px", sm: "24px" }}
+        fontFamily={"Amiri"}
+      >
+        {CHAINID === 1
+          ? "Please switch to Ethereum mainnet"
+          : "Please switch to Sepolia testnet"}
+      </Text>
+      <Image
+        src="/windows/swap/restricted-countries.png"
+        alt="Wrong network background"
+      />
+
+      <SubmitButtonContainer>
+        <PsyButton
+          customStyle={{ width: "100%", maxWidth: "550px" }}
+          onClick={() => {
+            openChainModal && openChainModal();
+          }}
+        >
+          {CHAINID === 1
+            ? "Switch to Ethereum Mainnet"
+            : "Switch to Sepolia Testnet"}
+        </PsyButton>
+      </SubmitButtonContainer>
+    </Flex>
+  );
+};
+
+export default WrongNetworkWindow;

--- a/components/nft-sale-widget/index.tsx
+++ b/components/nft-sale-widget/index.tsx
@@ -5,7 +5,9 @@ import {
   TabPanel,
   TabPanels,
   Tabs,
-  Grid
+  Grid,
+  Flex,
+  Text
 } from "@chakra-ui/react";
 import { Window } from "@/components/ui/window";
 import { useWindowManager } from "@/components/ui/window-manager";
@@ -20,9 +22,10 @@ import { InterimState } from "../commons/interim-state";
 import NFTSaleWidgetEmptyState from "./layout/nft-sale-widget-empty";
 import useGetOnlyWhitelistedSales from "@/hooks/useGetOnlyWhitelistedSales";
 import { useAccount } from "wagmi";
+import WrongNetworkWindow from "../commons/wrong-network";
 
 export const NftSaleWidget = ({ updateTrigger }: { updateTrigger: number }) => {
-  const { address } = useAccount();
+  const { address, chainId } = useAccount();
   const { whitelistedSales, loading: whitelistedSalesLoading } =
     useGetOnlyWhitelistedSales(address);
   const [activeSale, setActiveSale] = useState<Sale>();
@@ -38,6 +41,9 @@ export const NftSaleWidget = ({ updateTrigger }: { updateTrigger: number }) => {
         (whitelistedSalesLoading || whitelistedSales.length === 0)
     }
   );
+
+  const CHAINID = process.env.NEXT_PUBLIC_CHAIN_ID ?? 1;
+  const isWrongNetwork = chainId !== Number(CHAINID);
 
   useEffect(() => {
     if (
@@ -85,46 +91,50 @@ export const NftSaleWidget = ({ updateTrigger }: { updateTrigger: number }) => {
       <Window.TitleBar />
       <Window.Content py={2} px={0} height={"100%"} width={"100%"}>
         <TokenProvider>
-          <Tabs variant={"unstyled"}>
-            <MintPsycHeader
-              activeSale={activeSale}
-              setActiveSale={setActiveSale}
-              isOriginal={isOriginal}
-              setIsOriginal={setIsOriginal}
-            />
-            {address ? (
-              isLoading ? (
-                <InterimState type="loading" />
-              ) : error ? (
-                <InterimState type="error" />
-              ) : data ? (
-                <TabPanels>
-                  <TabPanel px={0}>
-                    <PsycSaleContent
-                      isFullScreen={fullScreenWindow}
-                      activeSale={activeSale}
-                      isOriginal={isOriginal}
-                    />
-                  </TabPanel>
-                  <TabPanel h="100%" w="100%">
-                    <OwnedNftsContent
-                      isFullScreen={fullScreenWindow}
-                      isOriginal={isOriginal}
-                      activeSale={activeSale}
-                    />
-                  </TabPanel>
-                </TabPanels>
+          {address && isWrongNetwork ? (
+            <WrongNetworkWindow />
+          ) : (
+            <Tabs variant={"unstyled"}>
+              <MintPsycHeader
+                activeSale={activeSale}
+                setActiveSale={setActiveSale}
+                isOriginal={isOriginal}
+                setIsOriginal={setIsOriginal}
+              />
+              {address ? (
+                isLoading ? (
+                  <InterimState type="loading" />
+                ) : error ? (
+                  <InterimState type="error" />
+                ) : data ? (
+                  <TabPanels>
+                    <TabPanel px={0}>
+                      <PsycSaleContent
+                        isFullScreen={fullScreenWindow}
+                        activeSale={activeSale}
+                        isOriginal={isOriginal}
+                      />
+                    </TabPanel>
+                    <TabPanel h="100%" w="100%">
+                      <OwnedNftsContent
+                        isFullScreen={fullScreenWindow}
+                        isOriginal={isOriginal}
+                        activeSale={activeSale}
+                      />
+                    </TabPanel>
+                  </TabPanels>
+                ) : (
+                  <Grid h={"100%"} w={"100%"} gridTemplateRows={"30% 1fr"}>
+                    <NFTSaleWidgetEmptyState address={address} />
+                  </Grid>
+                )
               ) : (
-                <Grid h={"100%"} w={"100%"} gridTemplateRows={"30% 1fr"}>
+                <Grid h={"100%"} w={"100%"} gridTemplateRows={"20% 1fr"}>
                   <NFTSaleWidgetEmptyState address={address} />
                 </Grid>
-              )
-            ) : (
-              <Grid h={"100%"} w={"100%"} gridTemplateRows={"20% 1fr"}>
-                <NFTSaleWidgetEmptyState address={address} />
-              </Grid>
-            )}
-          </Tabs>
+              )}
+            </Tabs>
+          )}
         </TokenProvider>
         <Image
           src="/windows/alchemist/clouds.png"

--- a/components/windows/swap-widget.tsx
+++ b/components/windows/swap-widget.tsx
@@ -26,6 +26,7 @@ import useGetTokenBalances from "@/services/web3/useGetTokenBalances";
 import { useWithdrawTokens } from "@/services/web3/useWithdrawTokens";
 import { useResize } from "@/hooks/useResize";
 import MintButton from "../ui/mint-button";
+import WrongNetworkWindow from "../commons/wrong-network";
 
 const SwapWidgetTitle = () => (
   <Box p={4} pb={8}>
@@ -188,7 +189,8 @@ export const SwapWidget = () => {
     isConfirmed: withdrawalConfirmed
   } = useWithdrawTokens(Number(tokensOwnedByUser), width);
 
-  const isWrongNetwork = chainId !== 1;
+  const CHAINID = process.env.NEXT_PUBLIC_CHAIN_ID ?? 1;
+  const isWrongNetwork = chainId !== Number(CHAINID);
 
   const { userBalance } = useGetTokenBalances(
     withdrawalConfirmed || tokenPurchaseSuccessful
@@ -254,42 +256,7 @@ export const SwapWidget = () => {
         ) : (
           <>
             {address && isWrongNetwork ? (
-              <>
-                <Flex p={2} pb={5} direction={"column"} gap={4}>
-                  <Text
-                    textColor="#269200"
-                    fontWeight="500"
-                    fontStyle="italic"
-                    mt="1"
-                    fontSize={{ base: "20px", sm: "36px" }}
-                    fontFamily={"Amiri"}
-                  >
-                    Wrong network!
-                  </Text>
-                  <Text
-                    textColor="#269200"
-                    fontWeight="500"
-                    fontStyle="italic"
-                    mt="1"
-                    fontSize={{ base: "14px", sm: "24px" }}
-                    fontFamily={"Amiri"}
-                  >
-                    Please switch to Ethereum mainnet
-                  </Text>
-                  <Image
-                    src="/windows/swap/restricted-countries.png"
-                    alt="Wrong network background"
-                  />
-
-                  <ConnectWalletButton
-                    tokenAmount={tokenAmount}
-                    walletBalance={formattedEthBalance}
-                    totalTokensForSaleValue={totalTokensForSaleValue}
-                    ethToSend={calculateEthAmount(tokenAmount)}
-                    isWrongNetwork={isWrongNetwork}
-                  />
-                </Flex>
-              </>
+              <WrongNetworkWindow />
             ) : (
               <>
                 {!fullScreenWindow && <SwapWidgetTitle />}


### PR DESCRIPTION
Improved the "wrong network" state and added it to both the buy widget and mint widget
NOTE: it is configured to show "switch to sepolia" if the env variable is not set to 1 (i.e., mainnet) and show "switch to ethereum mainnet" if the env variable is set to 1

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/83d8953e-a493-43fb-9321-127ef191ad0e">
