### PR TITLE
fix whitelist error

### DIFF
--- a/components/nft-sale-widget/psyc-item.tsx
+++ b/components/nft-sale-widget/psyc-item.tsx
@@ -93,7 +93,12 @@ const PsycItem = ({
 
   const proof = useFetchProof(address, item.ipfsHash, isPrivateSale);
 
-  const isWhitelisted = address ? item.whitelist.includes(address) : false;
+  const isWhitelisted = address
+    ? item.whitelist
+        .map((addr) => addr.toLowerCase())
+        .includes(address.toLowerCase())
+    : false;
+
   const modalNeeded = !address || (!isWhitelisted && isOriginal);
 
   const handleMint = async () => {


### PR DESCRIPTION
- when determining if the address is whitelisted, the addresses are normalized to lowercase on both sides of the comparison.