### PR TITLE
feat: toggle sale status for copy sales

### DIFF
--- a/components/nft-sale-widget/layout/owned-nfts/owned-nft-item.tsx
+++ b/components/nft-sale-widget/layout/owned-nfts/owned-nft-item.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/constants/contracts";
 import { useCustomToasts } from "@/hooks/useCustomToasts";
 import { useResize } from "@/hooks/useResize";
-import useToggleCopySales from "@/hooks/useToggleCopySales"; // Updated hook name
+import useToggleCopySales from "@/hooks/useToggleCopySales";
 import useReadTokenInformation from "@/hooks/useReadTokenInformation";
 
 interface OwnedNftItemProps {

--- a/components/nft-sale-widget/layout/owned-nfts/owned-nft-item.tsx
+++ b/components/nft-sale-widget/layout/owned-nfts/owned-nft-item.tsx
@@ -20,6 +20,9 @@ import {
   psyNFTMainnet,
   psyNFTSepolia
 } from "@/constants/contracts";
+import useActivateSale from "@/hooks/useActivateSale";
+import { useCustomToasts } from "@/hooks/useCustomToasts";
+import { useResize } from "@/hooks/useResize";
 
 interface OwnedNftItemProps {
   item: TokenItem & {
@@ -69,6 +72,24 @@ const OwnedNftItem = (props: OwnedNftItemProps) => {
     isMinting ||
     props.isOriginal ||
     props.isPrivateSale;
+
+  const { showCustomErrorToast } = useCustomToasts();
+  const { width } = useResize();
+  const { activateSale, isPending: isLoading } = useActivateSale();
+
+  const handleActivateSale = async () => {
+    console.log("activating copy sales for tokenId", props.item.tokenId);
+    try {
+      if (props.isOriginal && props.item.tokenId) {
+        await activateSale([parseInt(props.item.tokenId)]);
+      } else {
+        console.error("Sale Activation failed");
+      }
+    } catch (error) {
+      const message = (error as Error).message || "An error occurred";
+      showCustomErrorToast(message, width);
+    }
+  };
 
   const [isImageOpen, setIsImageOpen] = useState(false);
 
@@ -167,6 +188,24 @@ const OwnedNftItem = (props: OwnedNftItemProps) => {
             </MintButton>
           </GridItem>
         </Grid>
+      )}
+      {props.isOriginal && (
+        <MintButton
+          onClick={handleActivateSale}
+          customStyle={{
+            width: "100%"
+          }}
+          ownedView
+        >
+          {isLoading ? (
+            <>
+              <Spinner size="sm" mr={2} />
+              Activating
+            </>
+          ) : (
+            "Activate Copy Sales"
+          )}
+        </MintButton>
       )}
       <FullSizeImageModal
         isOpen={isImageOpen}

--- a/hooks/useImageData.tsx
+++ b/hooks/useImageData.tsx
@@ -24,7 +24,7 @@ const useImageData = (tokenIds: string[]) => {
     } else {
       setImageUris(Array(tokenIds.length).fill(FALLBACK_IMAGE));
     }
-  }, [data, tokenIds]);
+  }, [data]);
 
   return { imageUris, loading, error };
 };

--- a/hooks/useToggleCopySales.ts
+++ b/hooks/useToggleCopySales.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect } from "react";
+import { useWriteContract } from "wagmi";
+
+import ERC1155Abi from "../abis/ERC1155Abi.json";
+import ERC1155AbiSepolia from "../abis/ERC115AbiSepolia.json";
+import { ERC1155Mainnet, ERC1155Sepolia } from "../constants/contracts";
+import { useCustomToasts } from "./useCustomToasts";
+import { useResize } from "./useResize";
+
+const useToggleCopySales = () => {
+  const { writeContract, isPending, isSuccess, error } = useWriteContract();
+  const { width } = useResize();
+  const { showCustomErrorToast, showSuccessToast } = useCustomToasts();
+
+  const toggleSaleStatus = useCallback(
+    async (tokenIds: number[]) => {
+      writeContract({
+        address:
+          process.env.NEXT_PUBLIC_CHAIN_ID === "1"
+            ? ERC1155Mainnet
+            : ERC1155Sepolia,
+        abi:
+          process.env.NEXT_PUBLIC_CHAIN_ID === "1"
+            ? ERC1155Abi
+            : ERC1155AbiSepolia,
+        functionName: "switchSaleStatus",
+        args: [tokenIds]
+      });
+    },
+    [writeContract]
+  );
+
+  useEffect(() => {
+    if (isSuccess) {
+      showSuccessToast("Success! Sale status has been toggled.", width);
+    } else if (error) {
+      const message = (error as Error).message || "An error occurred";
+      showCustomErrorToast(message, width);
+    }
+  }, [isSuccess, error, width]);
+
+  return {
+    toggleSaleStatus,
+    isPending,
+    isSuccess,
+    error
+  };
+};
+
+export default useToggleCopySales;


### PR DESCRIPTION
- Added a button that appears exclusively for original owned NFTs.
- The button displays **Activate Copy Sale** if the sale is inactive, and **Deactivate Copy Sale** if the sale is active.
- When the button is clicked, MetaMask prompts the user to toggle the sale status.
- The button is disabled while the activation/deactivation process is ongoing.
- Users receive feedback upon success or failure.

- The `useToggleCopySales` hook is introduced to manage the activation and deactivation of copy sales. The hook encapsulates the logic for toggling the sale status on the blockchain, handling the interaction with the smart contract, and providing feedback to the user.

WIP: Refetching the active/inactive state to ensure the correct CTA is displayed after the user's action is still in progress.