### PR TITLE
fix: claims formatting issue

### DIFF
--- a/components/claim/claim-card.tsx
+++ b/components/claim/claim-card.tsx
@@ -4,7 +4,8 @@ import { type ClaimStatus } from "@/lib/types";
 import { useClaim } from "@/services/web3/useClaim";
 import { getExpirationStatus } from "@/utils/getExpirationStatus";
 import { Box, Button, Divider, Flex, Text } from "@chakra-ui/react";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
+import { formatUnits } from "viem";
 
 export interface ClaimCardProps {
   amount: string;
@@ -70,6 +71,18 @@ const ClaimCard = (props: ClaimCardProps) => {
     }
   }, [isSuccess, writeContractSuccess, txError, error]);
 
+  const formattedAmount = useMemo(() => {
+    try {
+      // Format from wei (18 decimals) to a human-readable number
+      const formatted = formatUnits(BigInt(amount), 18)
+      // Round to 2 decimal places
+      return Number(formatted).toFixed(2)
+    } catch (err) {
+      console.error('Error formatting amount:', err)
+      return '0.00'
+    }
+  }, [amount])
+
   return (
     <Flex
       maxW={"593px"}
@@ -102,7 +115,7 @@ const ClaimCard = (props: ClaimCardProps) => {
             md: "16px"
           }}
         >
-          {parseFloat(amount).toFixed(2)} PSY
+          {formattedAmount} PSY
         </Text>
         <Divider borderColor={"#E0E0E0"} my={3} />
         <ClaimCardText text={`${getExpirationStatus(expiry)}`} />


### PR DESCRIPTION
## Work Done
- use `formatUnits` from `viem`
- imported `useMemo` to create the `formattedAmount` string
- closes [#147](https://github.com/LinumLabs/PsyDao-FE/issues/147)

### Before
![image](https://github.com/user-attachments/assets/348f48de-c0f4-4763-a060-a33555a9fb7c)


### After
<img width="1437" alt="Screenshot 2024-10-31 at 10 28 10" src="https://github.com/user-attachments/assets/062652b7-9fd5-4861-9f46-6c09c96e8449">
