### PR TITLE
fix: get correct psyc holders

### DIFF
--- a/lib/services/getPsycHolders.ts
+++ b/lib/services/getPsycHolders.ts
@@ -1,4 +1,4 @@
-import { getNFTHolders, getNFTHoldersByTimestamps } from "@/services/graph";
+import { getNFTHolders, getNFTHoldersBeforeTimestamp } from "@/services/graph";
 import { psycGraphQLClient, psycMainnetGraphQLClient } from "../../config/graphqlClients";
 import { Address } from "viem";
 
@@ -28,15 +28,14 @@ export const getPsycHolders = async (blockNumber: number) => {
 /**
  * Get the owners of the Psyc NFTs on the mainnet by timestamps
  * 
- * @param startTimeStamp - The start timestamp to query
  * @param endTimeStamp - The end timestamp to query
  * @returns An array of PsycHolder objects
  */
-export const getPsycHoldersByTimestamps = async (startTimeStamp: number, endTimeStamp: number) => {
+export const getPsycHoldersBeforeTimestamp = async (endTimeStamp: number) => {
   try {
     const data = await psycMainnetGraphQLClient.request<{ tokens: PsycHolder[] }>(
-      getNFTHoldersByTimestamps,
-      { startTimeStamp, endTimeStamp }
+      getNFTHoldersBeforeTimestamp,
+      { endTimeStamp }
     );
     return data.tokens;
   } catch (err) {

--- a/lib/services/getPsycHoldersNoProposals.ts
+++ b/lib/services/getPsycHoldersNoProposals.ts
@@ -1,4 +1,4 @@
-import { getPsycHoldersByTimestamps } from "./getPsycHolders";
+import { getPsycHoldersBeforeTimestamp } from "./getPsycHolders";
 import { keccak256, encodePacked, parseUnits, Address } from "viem";
 import { MerkleTree } from "merkletreejs";
 import { Balance, uploadArrayToIpfs } from "./ipfs";
@@ -6,13 +6,12 @@ import { userTestMapping } from "./config/test-mapping";
 import { TEST_ENV } from "@/constants/claims";
 
 export const psycHoldersNoProposals = async (
-  startTimeStamp: number,
   endTimeStamp: number,
   totalAmountOfTokens: number,
   batchId: number
 ) => {
   let balances: Balance[] = [];
-  const sgData = await getPsycHoldersByTimestamps(startTimeStamp, endTimeStamp);
+  const sgData = await getPsycHoldersBeforeTimestamp(endTimeStamp);
 
   const psycHolders = sgData.map((psycHolder) =>
     TEST_ENV

--- a/lib/services/voteCounter.test.ts
+++ b/lib/services/voteCounter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { main } from './voteCounter'
-import { getPsycHolders, getPsycHoldersByTimestamps, PsycHolder } from './getPsycHolders'
+import { getPsycHolders, getPsycHoldersBeforeTimestamp, PsycHolder } from './getPsycHolders'
 import { getSnapshotProposals, getVotesOnProposalById, Proposal, type Vote } from './getSnapshotProposalsAndVotes'
 import { uploadArrayToIpfs } from './ipfs'
 
@@ -77,7 +77,7 @@ describe('voteCounter main function', () => {
     ]
 
     vi.mocked(getSnapshotProposals).mockResolvedValue([])
-    vi.mocked(getPsycHoldersByTimestamps).mockResolvedValue(mockHoldersInPeriod)
+    vi.mocked(getPsycHoldersBeforeTimestamp).mockResolvedValue(mockHoldersInPeriod)
     vi.mocked(uploadArrayToIpfs).mockResolvedValue('QmHash123')
 
     const result = await main(

--- a/lib/services/voteCounter.ts
+++ b/lib/services/voteCounter.ts
@@ -91,7 +91,7 @@ export const main = async (
   }
 
   if (proposals?.length === 0) {
-    const emptyProposalsCalculation = await psycHoldersNoProposals(startTimeStamp, endTimeStamp, totalAmountOfTokens, batchId);
+    const emptyProposalsCalculation = await psycHoldersNoProposals(endTimeStamp, totalAmountOfTokens, batchId);
     return emptyProposalsCalculation;
   }
 

--- a/services/graph.ts
+++ b/services/graph.ts
@@ -193,13 +193,12 @@ export const getNFTHolders = gql`
  * The hardcoded address `0x6c6ab7b3215374de4a65de63eac9bc7a0c7f402d` 
  * is the NFT contract address on mainnet 
  */
-export const getNFTHoldersByTimestamps = gql`
-  query NFTHolders($startTimeStamp: Int!, $endTimeStamp: Int!) {
+export const getNFTHoldersBeforeTimestamp = gql`
+  query NFTHolders($endTimeStamp: Int!) {
     tokens(
       where: {
         tokenAddress: "0x6c6ab7b3215374de4a65de63eac9bc7a0c7f402d"
-        blockTimestamp_gte: $startTimeStamp
-        blockTimestamp_lt: $endTimeStamp
+        blockTimestamp_lte: $endTimeStamp
       }
       orderBy: tokenId
       orderDirection: asc


### PR DESCRIPTION
## Work Done

- changed the `no proposals` code path to fetch all PsyC holders before the `endTimestamp`
- renamed and refactored all the functions along this code path
- renamed and refactored the `gql` code to fetch only holders before/equal to the timestamp