### PR TITLE
fix: Piñata not storing ipfs hashes properly

### DIFF
--- a/lib/services/getPsycHoldersNoProposals.ts
+++ b/lib/services/getPsycHoldersNoProposals.ts
@@ -1,7 +1,7 @@
 import { getPsycHoldersBeforeTimestamp } from "./getPsycHolders";
 import { keccak256, encodePacked, parseUnits, Address } from "viem";
 import { MerkleTree } from "merkletreejs";
-import { Balance, uploadArrayToIpfs } from "./ipfs";
+import { Balance, pinListToIpfs, uploadArrayToIpfs } from "./ipfs";
 import { userTestMapping } from "./config/test-mapping";
 import { TEST_ENV } from "@/constants/claims";
 
@@ -44,7 +44,8 @@ export const psycHoldersNoProposals = async (
   const tree = new MerkleTree(leaves, keccak256, { sortPairs: true });
   const merkleRoot = tree.getHexRoot();
 
-  const ipfsHash = await uploadArrayToIpfs(balances);
-
+  // const ipfsHash = await uploadArrayToIpfs(balances);
+  const ipfsHash = await pinListToIpfs(balances);
+  console.log("no proposal IPFS is ", ipfsHash);
   return { balances, merkleRoot, ipfsHash };
 };

--- a/lib/services/ipfs.ts
+++ b/lib/services/ipfs.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { PinataMetadata, PinataSDK } from "pinata-web3";
 import { env } from "@/config/env.mjs";
 
 export interface Balance {
@@ -35,3 +36,36 @@ export const getIpfsHash = async (ipfsHash: string) => {
   );
   return response.data;
 };
+
+export async function pinListToIpfs(merkleList: Balance[]) {
+  try {
+    const pinata = new PinataSDK({
+      pinataJwt: process.env.PINATA_ADMIN_JWT!,
+      pinataGateway: "red-literary-tiglon-645.mypinata.cloud"
+    })
+
+    const options = {
+      pinataOptions: {
+        cidVersion: 0,
+        customPinPolicy: {
+          regions: [{ id: "FRA1", desiredReplicationCount: 1 }]
+        }
+      },
+      pinataMetadata: {
+        name: `PsyDAO Merkle Tree Data ${new Date().toISOString()}`,
+        keyvalues: {
+          type: "merkle-tree-data"
+        }
+      },
+      groupId: "fa33eb74-0699-443c-8f1b-a8bf15c74360" // PsyDao's groupId
+    };
+
+    const upload = await pinata.upload.json(merkleList, options);
+
+    const ipfsHash = upload.IpfsHash;
+
+    return ipfsHash;
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "multiformats": "^13.2.0",
     "next": "^14.1.3",
     "pinata": "^0.3.4",
+    "pinata-web3": "^0.5.2",
     "react": "^18.2.0",
     "react-cookie": "^7.1.0",
     "react-dom": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7150,6 +7150,16 @@ pify@^5.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-5.0.0.tgz#1f5eca3f5e87ebec28cc6d54a0e4aaf00acc127f"
   integrity sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==
 
+pinata-web3@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/pinata-web3/-/pinata-web3-0.5.2.tgz#78cfa17c2453192f64340c43898626f2db0bd809"
+  integrity sha512-MywymvEvm03EltT3lsUkjUfcVf9NKKHQ8uT+SzIPeEGxs1TwUoGwpOZ/DKgdzo7660UtWe9IIsyItkyIH39mKg==
+  dependencies:
+    axios "^1.7.7"
+    form-data "^4.0.0"
+    is-ipfs "^8.0.4"
+    node-fetch "^3.3.1"
+
 pinata@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/pinata/-/pinata-0.3.4.tgz#60297d1c6b88aba2f2180a6c1c0498f7585a786a"


### PR DESCRIPTION
## Work Done

- used the piñata web3 sdk
- added the PsyDao piñata group id
- using the piñata admin JWT Token