### PR TITLE
fix(claims): adding decimals

### DIFF
--- a/lib/services/firstProposalsApproved.test.ts
+++ b/lib/services/firstProposalsApproved.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { firstProposals } from "./firstProposalsApproved"
+import { getPsycHolders, type PsycHolder } from "./getPsycHolders"
+import { uploadArrayToIpfs } from "./ipfs"
+
+// Mock env before any other imports
+vi.mock("@/config/env.mjs", () => ({
+  env: {
+    // Add only the env variables used in the test
+    SNAPSHOT_GRAPHQL_URL: "https://hub.snapshot.org/graphql",
+    NEXT_PUBLIC_SUBGRAPH_URL:
+      "https://api.studio.thegraph.com/query/83978/psydao-sepolia/version/latest",
+    NEXT_PUBLIC_MAINNET_SUBGRAPH_URL:
+      "https://api.studio.thegraph.com/query/83978/psydao-mainnet/version/latest",
+    NEXT_PUBLIC_CHAIN_ID: 1,
+    PINATA_JWT: "test-jwt",
+    PINATA_API_KEY: "test-key",
+    PINATA_SECRET_API_KEY: "test-secret"
+  }
+}));
+
+// Mock dependencies
+vi.mock("./getPsycHolders")
+vi.mock("./ipfs")
+vi.mock("@/constants/claims", () => ({
+  SNAPSHOT_GRAPHQL_URL: "https://hub.snapshot.org/graphql",
+  PSYDAO_ENS: "psydao.eth",
+  NEXT_PUBLIC_SUBGRAPH_URL:
+    "https://api.studio.thegraph.com/query/83978/psydao-sepolia/version/latest",
+  NEXT_PUBLIC_MAINNET_SUBGRAPH_URL:
+    "https://api.studio.thegraph.com/query/83978/psydao-mainnet/version/latest"
+}));
+
+describe("firstProposals", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it("should distribute tokens equally with exact precision", async () => {
+    // Mock the exact case that was failing before
+    const mockHolders = [
+      { owner: "0xc3ac5ef1a15c40241233c722fe322d83b010e445" },
+      { owner: "0x5de3f8b1e1c758c3fe0b300aa376da229a732dc9" },
+      { owner: "0x407a6d10206f40a7aec3046fc17c4a186171b4e7" }
+    ] as PsycHolder[]
+
+    vi.mocked(getPsycHolders).mockResolvedValue(mockHolders)
+    vi.mocked(uploadArrayToIpfs).mockResolvedValue("QmHash123")
+
+    const totalAmount = 767506.10
+    const result = await firstProposals(1726005600, totalAmount, 25)
+
+    // Each holder should get exactly 255835.36666666667
+    const expectedPerHolder = "255835.36666666667"
+
+    result.psycHolderTokenDistribution.forEach(holder => {
+      expect(holder.tokens).toBe(expectedPerHolder)
+    })
+
+    // Verify total equals input amount
+    const totalDistributed = result.psycHolderTokenDistribution
+      .reduce((sum, holder) => sum + Number(holder.tokens), 0)
+
+    expect(totalDistributed).toBe(totalAmount)
+  })
+
+  it("should handle different numbers of holders", async () => {
+    const mockHolders = [
+      { owner: "0xc3ac5ef1a15c40241233c722fe322d83b010e445" },
+      { owner: "0x5de3f8b1e1c758c3fe0b300aa376da229a732dc9" },
+      { owner: "0x407a6d10206f40a7aec3046fc17c4a186171b4e7" },
+      { owner: "0x07effc25352088e044d2e91e57d06877c5d49e46" },
+      { owner: "0x1885754425d75bddce43bd82f24f160d8f6abadf" }
+    ] as PsycHolder[]
+
+    vi.mocked(getPsycHolders).mockResolvedValue(mockHolders)
+    vi.mocked(uploadArrayToIpfs).mockResolvedValue("QmHash123")
+
+    const totalAmount = 767506.15
+    const result = await firstProposals(1726005600, totalAmount, 25)
+
+    expect(result.psycHolderTokenDistribution).toHaveLength(5)
+
+    // Verify each holder gets equal amount
+    const firstAmount = result.psycHolderTokenDistribution[0]?.tokens
+    result.psycHolderTokenDistribution.forEach(holder => {
+      expect(holder.tokens).toBe(firstAmount)
+    })
+
+    // Verify total equals input amount
+    const totalDistributed = result.psycHolderTokenDistribution
+      .reduce((sum, holder) => sum + Number(holder.tokens), 0)
+
+    expect(totalDistributed).toBe(totalAmount)
+  })
+
+  it("should generate valid merkle tree and root", async () => {
+    const mockHolders = [
+      { owner: "0xc3ac5ef1a15c40241233c722fe322d83b010e445" },
+      { owner: "0x5de3f8b1e1c758c3fe0b300aa376da229a732dc9" },
+    ] as PsycHolder[]
+
+    vi.mocked(getPsycHolders).mockResolvedValue(mockHolders)
+    vi.mocked(uploadArrayToIpfs).mockResolvedValue("QmHash123")
+
+    const result = await firstProposals(1726005600, 1000, 25)
+
+    expect(result.merkleRoot).toBeDefined()
+    expect(result.merkleRoot).toMatch(/^0x[a-fA-F0-9]{64}$/)
+  })
+
+  it("should handle single holder case", async () => {
+    const mockHolders = [
+      { owner: "0xc3ac5ef1a15c40241233c722fe322d83b010e445" },
+    ] as PsycHolder[]
+
+    vi.mocked(getPsycHolders).mockResolvedValue(mockHolders)
+    vi.mocked(uploadArrayToIpfs).mockResolvedValue("QmHash123")
+
+    const totalAmount = 767506.15
+    const result = await firstProposals(1726005600, totalAmount, 25)
+
+    expect(result.psycHolderTokenDistribution).toHaveLength(1)
+    expect(Number(result.psycHolderTokenDistribution[0]?.tokens)).toBe(totalAmount)
+  })
+
+  it("should handle error in getPsycHolders", async () => {
+    vi.mocked(getPsycHolders).mockRejectedValue(new Error("API Error"))
+
+    await expect(
+      firstProposals(1726005600, 1000, 25)
+    ).rejects.toThrow("API Error")
+  })
+
+  it("should handle error in IPFS upload", async () => {
+    const mockHolders = [{ owner: "0xc3ac5ef1a15c40241233c722fe322d83b010e445" }] as PsycHolder[]
+
+    vi.mocked(getPsycHolders).mockResolvedValue(mockHolders)
+    vi.mocked(uploadArrayToIpfs).mockRejectedValue(new Error("IPFS Error"))
+
+    await expect(
+      firstProposals(1726005600, 1000, 25)
+    ).rejects.toThrow("IPFS Error")
+  })
+
+  it("should handle empty holders array", async () => {
+    vi.mocked(getPsycHolders).mockResolvedValue([])
+    vi.mocked(uploadArrayToIpfs).mockResolvedValue("QmHash123")
+
+    const result = await firstProposals(1726005600, 1000, 25)
+
+    expect(result.psycHolderTokenDistribution).toHaveLength(0)
+    expect(result.merkleRoot).toBeDefined()
+    expect(result.ipfsHash).toBe("QmHash123")
+  })
+
+  it("should maintain precision with large numbers of holders", async () => {
+    // Create 100 mock holders
+    const mockHolders = Array.from({ length: 100 }, (_, i) => ({
+      owner: `0x${i.toString().padStart(40, '0')}`
+    })) as PsycHolder[]
+
+    vi.mocked(getPsycHolders).mockResolvedValue(mockHolders)
+    vi.mocked(uploadArrayToIpfs).mockResolvedValue("QmHash123")
+
+    const totalAmount = 767506.15
+    const result = await firstProposals(1726005600, totalAmount, 25)
+
+    // Verify total distributed equals input amount
+    const totalDistributed = result.psycHolderTokenDistribution
+      .reduce((sum, holder) => sum + Number(holder.tokens), 0)
+
+    expect(totalDistributed).toBe(totalAmount)
+  })
+})

--- a/lib/services/firstProposalsApproved.ts
+++ b/lib/services/firstProposalsApproved.ts
@@ -11,27 +11,55 @@ export const firstProposals = async (
   let psycHolderTokenDistribution: Balance[] = [];
   const sgData = await getPsycHolders(endTimeStamp);
   const psycHolders = sgData.map((psycHolder: any) => psycHolder.owner);
-  const tokenPerHolder = totalAmountOfTokens / psycHolders.length;
+
+  // Calculate exact token amount per holder with full precision
+  const tokenPerHolder = (totalAmountOfTokens / psycHolders.length)
+    .toLocaleString('fullwide', {
+      useGrouping: false,
+      minimumFractionDigits: 11,
+      maximumFractionDigits: 11
+    });
+
   // Calculate the amount of tokens each psyc holder gets based on the percentage of votes they have
   psycHolderTokenDistribution = psycHolders.map((psycHolder) => {
     return {
       address: psycHolder as `0x${string}`,
-      tokens: tokenPerHolder.toString()
+      tokens: tokenPerHolder
     };
   });
-  const leaves = psycHolderTokenDistribution.map((holder) =>
-    keccak256(
+
+  // Verify total equals input amount
+  const totalDistributed = psycHolderTokenDistribution
+    .reduce((sum, holder) => sum + Number(holder.tokens), 0)
+    .toLocaleString('fullwide', {
+      useGrouping: false,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    });
+
+  const leaves = psycHolderTokenDistribution.map((holder) => {
+    // const tokenAmount = Number(holder.tokens)
+    //   .toLocaleString('fullwide', {
+    //     useGrouping: false,
+    //     minimumFractionDigits: 0,
+    //     maximumFractionDigits: 18
+    //   });
+    const tokenAmount = holder.tokens
+      .replace(/\.?0+$/, ''); // Remove trailing zeros but keep decimal precision
+
+    return keccak256(
       encodePacked(
         ["uint256", "uint256", "address"],
         [
           BigInt(batchId),
-          parseUnits(holder.tokens, 18),
+          parseUnits(tokenAmount, 18),
           holder.address as `0x${string}`
         ]
       )
     )
-  );
-  const tree = new MerkleTree(leaves);
+  });
+
+  const tree = new MerkleTree(leaves, keccak256, { sortPairs: true });
   const merkleRoot = tree.getHexRoot();
 
   const ipfsHash = await uploadArrayToIpfs(psycHolderTokenDistribution);

--- a/lib/services/voteCounter.test.ts
+++ b/lib/services/voteCounter.test.ts
@@ -329,4 +329,95 @@ describe("voteCounter main function", () => {
       ipfsHash: ""
     });
   });
+
+  it("should maintain exact precision with no rounding errors", async () => {
+    const mockProposal = {
+      id: "0x123",
+      snapshot: "123456",
+      start: 1723932000,
+      end: 1726005600
+    }
+
+    // Test with 3 holders
+    const mockPsycHolders = [
+      { owner: "0xd9c0bb3476ce2ad2102d3ac07287bb802eea98f1" },
+      { owner: "0x5de3f8b1e1c758c3fe0b300aa376da229a732dc9" },
+      { owner: "0xf2217ba914d9c07b81c5e4b10a2eb2ec478d49aa" }
+    ] as PsycHolder[]
+
+    // Make sure votes match holder addresses
+    const mockVotes = mockPsycHolders.map((holder, index) => ({
+      id: `vote${index}`,
+      voter: holder.owner.toLowerCase(),
+      created: 1723932100 + index
+    }))
+
+    vi.mocked(getSnapshotProposals).mockResolvedValue([mockProposal])
+    vi.mocked(getPsycHolders).mockResolvedValue(mockPsycHolders)
+    vi.mocked(getVotesOnProposalById).mockResolvedValue(mockVotes)
+    vi.mocked(pinClaimsListToIpfs).mockResolvedValue("QmHash123")
+
+    const totalAmount = 767506.15
+    const result = await main(1723932000, 1726005600, totalAmount, 25)
+
+    // Convert all numbers to strings with full precision for comparison
+    const totalDistributed = result.balances
+      .reduce((sum, balance) => sum + Number(balance.tokens), 0)
+      .toString()
+
+    expect(totalDistributed).toBe(totalAmount.toString())
+
+    // Verify that the last person can claim
+    const lastBalance = Number(
+      result.balances[result.balances.length - 1]?.tokens
+    )
+    const sumWithoutLast = result.balances
+      .slice(0, -1)
+      .reduce((sum, balance) => sum + Number(balance.tokens), 0)
+
+    expect(sumWithoutLast + lastBalance).toBe(totalAmount)
+  })
+
+  it("should handle the exact distribution case that was failing", async () => {
+    const mockProposal = {
+      id: "0x123",
+      snapshot: "123456",
+      start: 1723932000,
+      end: 1726005600
+    }
+
+    // Recreate the exact case that was failing
+    const mockPsycHolders = [
+      { owner: "0xc3ac5ef1a15c40241233c722fe322d83b010e445" },
+      { owner: "0x5de3f8b1e1c758c3fe0b300aa376da229a732dc9" },
+      { owner: "0x407a6d10206f40a7aec3046fc17c4a186171b4e7" }
+    ] as PsycHolder[]
+
+    const mockVotes = mockPsycHolders.map((holder, index) => ({
+      id: `vote${index}`,
+      voter: holder.owner,
+      created: 1723932100 + index
+    }))
+
+    vi.mocked(getSnapshotProposals).mockResolvedValue([mockProposal])
+    vi.mocked(getPsycHolders).mockResolvedValue(mockPsycHolders)
+    vi.mocked(getVotesOnProposalById).mockResolvedValue(mockVotes)
+    vi.mocked(pinClaimsListToIpfs).mockResolvedValue("QmHash123")
+
+    const totalAmount = 767506.10
+    const result = await main(1723932000, 1726005600, totalAmount, 25)
+
+    // Each holder should get exactly 255835.36666666667
+    const expectedPerHolder = "255835.36666666667"
+
+    result.balances.forEach(balance => {
+      expect(balance.tokens).toBe(expectedPerHolder)
+    })
+
+    // Verify exact sum
+    const totalDistributed = result.balances
+      .reduce((sum, balance) => sum + Number(balance.tokens), 0)
+
+    expect(totalDistributed).toBe(totalAmount)
+  })
 });

--- a/lib/services/voteCounter.ts
+++ b/lib/services/voteCounter.ts
@@ -66,7 +66,7 @@ export const main = async (
       ([address, count]) => {
         return {
           address: address as Address,
-          percentage: Number((count / filteredProposals.length).toFixed(2))
+          percentage: count / filteredProposals.length
         };
       }
     );
@@ -74,11 +74,12 @@ export const main = async (
     // Calculate the amount of tokens each psyc holder gets based on the percentage of votes they have
     psycHolderTokenDistribution = psycHolderVotesPercentage.map(
       (psycHolder) => {
+        const tokens = psycHolder.percentage * tokenPerHolder;
         return {
           address: psycHolder.address,
-          tokens: Number(psycHolder.percentage.toFixed(2)) * tokenPerHolder,
+          tokens: tokens,
           percentage: psycHolder.percentage,
-          leftOver: tokenPerHolder - psycHolder.percentage * tokenPerHolder
+          leftOver: tokenPerHolder - tokens
         };
       }
     );
@@ -100,28 +101,35 @@ export const main = async (
 
   // Upload array to IPFS and get the hash
   const balances: Balance[] = psycHolderTokenDistribution.map((holder) => {
+    const finalTokens = (
+      holder.tokens +
+      (unAllocatedTokens * (votesCountMap[holder.address] ?? 0)) / totalVotes
+    ).toFixed(11) // Increase precision to 11 decimal places
     return {
       address: holder.address,
-      tokens: (
-        holder.tokens +
-        (unAllocatedTokens * (votesCountMap[holder.address] ?? 0)) / totalVotes
-      ).toFixed(10)
+      tokens: finalTokens
     };
   });
 
-  const leaves = balances.map((holder) =>
-    keccak256(
+  const leaves = balances.map((holder) => {
+    const tokenAmount = Number(holder.tokens)
+      .toLocaleString("fullwide", {
+        useGrouping: false,
+        maximumFractionDigits: 20
+      })
+      .replace(/\.?0+$/, '');
+
+    return keccak256(
       encodePacked(
         ["uint256", "uint256", "address"],
-        [BigInt(batchId), parseUnits(holder.tokens, 18), holder.address]
+        [BigInt(batchId), parseUnits(tokenAmount, 18), holder.address]
       )
     )
-  );
+  });
 
   const tree = new MerkleTree(leaves, keccak256, { sortPairs: true });
   const merkleRoot = tree.getHexRoot();
 
-  console.log("with proposals ipfs upload");
   const ipfsHash = await pinClaimsListToIpfs(balances);
   return { balances, merkleRoot, ipfsHash };
 };


### PR DESCRIPTION
# WIP: Improving Token Distribution Precision

## Current Status
- 7/8 tests passing
- One remaining precision issue with large numbers of holders

## Changes Made
1. Added comprehensive test suite for token distribution
2. Improved number formatting with `toLocaleString('fullwide')`
3. Added validation for total distributed amounts
4. Enhanced merkle tree generation with `sortPairs: true`

## Remaining Issue
Test failing:
```bash
 FAIL  lib/services/firstProposalsApproved.test.ts > firstProposals > should maintain precision with large numbers of holders
AssertionError: expected 767506.149999999 to be 767506.15 // Object.is equality

- Expected
+ Received

- 767506.15
+ 767506.149999999
```

This indicates we still have a floating-point precision issue when:
1. Dividing the total amount by a large number of holders
2. Summing up the distributed amounts

## Next Steps
1. Consider using BigInt for all calculations
2. Investigate alternative decimal handling approaches
3. May need to adjust precision handling in the reduction step
4. Consider fixed-point arithmetic instead of floating-point

## Testing Notes
- 7 tests pass including edge cases and error handling
- Large holder count test reveals remaining precision issue
- Need to resolve final floating-point accumulation error

## Questions for Review
1. Should we use BigInt throughout?
2. Is there a better way to handle the reduction/sum operation?
3. What precision level do we actually need for the contract?