### PR TITLE
feat: show pending rewards on user cards

### DIFF
--- a/components/freebase/pool-card.tsx
+++ b/components/freebase/pool-card.tsx
@@ -93,7 +93,11 @@ export function PoolCard({ pool, userAddress, rewardTokens, userPoolPosition }: 
         )}
         {pendingRewards && (
           <Text fontSize="sm" color="gray.600" mb={4}>
-            Pending Rewards: {formatUnits(pendingRewards, 18)}
+            Pending Rewards: {
+              pendingRewards && BigInt(pendingRewards) > BigInt(0)
+                ? Number(formatUnits(pendingRewards, 18)).toFixed(2)
+                : formatUnits(pendingRewards, 18)
+            }
           </Text>
         )}
 

--- a/components/freebase/pool-card.tsx
+++ b/components/freebase/pool-card.tsx
@@ -1,9 +1,10 @@
 import { Box, Button, Card, CardBody, CardHeader, CardFooter, Flex, Text, Input } from "@chakra-ui/react";
-import { usePoolInteraction } from "@/hooks/useFreebaseUser";
+import { usePoolInteraction, usePendingRewards } from "@/hooks/useFreebaseUser";
 import { useState } from "react";
 import { formatUnits, type Address } from "viem";
 import { useTokenInfo } from "@/hooks/useTokenInfo";
 import { FreebaseToken, FreebaseUserPoolPosition } from "@/lib/services/freebase";
+
 
 interface PoolCardProps {
   pool: {
@@ -34,7 +35,7 @@ export function PoolCard({ pool, userAddress, rewardTokens, userPoolPosition }: 
     poolInteractionPending
   } = usePoolInteraction(BigInt(pool.id));
   const { symbol, decimals } = useTokenInfo(pool.tokenAddress);
-
+  const { pendingRewards } = usePendingRewards(BigInt(pool.id), userAddress as Address);
   const handleDeposit = () => {
     if (!amount) return;
     deposit({ amount: BigInt(amount) });
@@ -88,6 +89,11 @@ export function PoolCard({ pool, userAddress, rewardTokens, userPoolPosition }: 
         {userPoolPosition?.amount && (
           <Text fontSize="sm" color="gray.600" mb={4}>
             Deposited Tokens: {formatUnits(userPoolPosition?.amount, 18)}
+          </Text>
+        )}
+        {pendingRewards && (
+          <Text fontSize="sm" color="gray.600" mb={4}>
+            Pending Rewards: {formatUnits(pendingRewards, 18)}
           </Text>
         )}
 

--- a/hooks/useFreebaseUser.tsx
+++ b/hooks/useFreebaseUser.tsx
@@ -208,19 +208,22 @@ export function useRewards(address: Address) {
 
 // Additional hook for pending rewards
 export function usePendingRewards(poolId: bigint, userAddress: Address) {
-  const { data: pendingRewards } = useReadContract({
+  const { data: pendingRewards, error, isError } = useReadContract({
     address: FREEBASE_ADDRESS,
     abi: FREEBASE_ABI,
     functionName: "pendingRewards",
     args: [poolId, userAddress],
     query: {
       refetchInterval: 10_000,
-      refetchIntervalInBackground: false
+      refetchIntervalInBackground: false,
+      enabled: Boolean(poolId && userAddress)
     }
   });
 
   return {
-    pendingRewards: pendingRewards as bigint | undefined
+    pendingRewards: pendingRewards as bigint | undefined,
+    error,
+    isError
   };
 }
 

--- a/hooks/useFreebaseUser.tsx
+++ b/hooks/useFreebaseUser.tsx
@@ -212,7 +212,11 @@ export function usePendingRewards(poolId: bigint, userAddress: Address) {
     address: FREEBASE_ADDRESS,
     abi: FREEBASE_ABI,
     functionName: "pendingRewards",
-    args: [poolId, userAddress]
+    args: [poolId, userAddress],
+    query: {
+      refetchInterval: 10_000,
+      refetchIntervalInBackground: false
+    }
   });
 
   return {


### PR DESCRIPTION
## Work Done
- add a hook to fetch pending rewards from the freebase contract
- add a `refetchInterval` to hook fetching the pending rewards
- display the pending rewards on the User Card if it exists
- limit the decimal places from the pending rewards to 2 places

## Screenshot
![Screenshot 2025-01-03 at 14 15 48](https://github.com/user-attachments/assets/ec9f90d3-6c27-435f-9305-85d929284d7c)

## Screenshot with Metamask
![Screenshot 2025-01-03 at 14 17 24](https://github.com/user-attachments/assets/f66f8721-c3d5-4822-a126-ddcc9fd1e3e8)
