### PR TITLE
fix: add decimals to reward token adding

### DIFF
--- a/components/freebase/manage-reward-token.tsx
+++ b/components/freebase/manage-reward-token.tsx
@@ -17,7 +17,7 @@ import { type Address } from "viem";
 import { useRewardTokens } from "@/hooks/useFreebaseUser";
 
 interface ManageRewardTokenProps {
-  onAddReward: (args: { rewardToken: Address; transferAmount: bigint }) => void;
+  onAddReward: (args: { rewardToken: Address; transferAmount: string }) => void;
   onSetReward: (args: { rewardToken: Address }) => void;
   isPendingAddReward: boolean;
   isPendingSetReward: boolean;
@@ -38,7 +38,7 @@ export default function ManageRewardToken({
     if (!rewardToken || !transferAmount) return;
     onAddReward({
       rewardToken: rewardToken as Address,
-      transferAmount: BigInt(transferAmount)
+      transferAmount
     });
     setRewardToken("");
     setTransferAmount("");

--- a/components/freebase/token-management.tsx
+++ b/components/freebase/token-management.tsx
@@ -16,7 +16,7 @@ interface TokenManagementProps {
   onAddReward: {
     addRewardToken: (args: {
       rewardToken: Address;
-      transferAmount: bigint;
+      transferAmount: string;
     }) => void;
     isPending: boolean;
   };

--- a/hooks/useFreebaseAdmin.tsx
+++ b/hooks/useFreebaseAdmin.tsx
@@ -22,7 +22,7 @@ interface AddDepositTokenParams {
 
 interface AddRewardTokenParams {
   rewardToken: Address;
-  transferAmount: bigint;
+  transferAmount: string;
 }
 
 interface SetRewardTokenParams {
@@ -79,7 +79,7 @@ export function useRewardTokenManagement() {
   const { writeContract, isPending: isWritePending } = useWriteContract();
   const [pendingReward, setPendingReward] = useState<{
     token: Address;
-    amount: bigint;
+    amount: string;
   } | null>(null);
   const { showSuccessToast } = useCustomToasts();
   const { width } = useResize();
@@ -113,7 +113,7 @@ export function useRewardTokenManagement() {
 
       // NOTE currently all tokens in this contract use 18 decimals
       const parsedAllowance = parseEther(allowance?.toString() ?? "0");
-      const parsedPendingReward = parseEther(pendingReward.amount.toString());
+      const parsedPendingReward = parseEther(pendingReward.amount);
 
       if (parsedAllowance >= parsedPendingReward) {
         // Allowance is sufficient, proceed with contract call


### PR DESCRIPTION
# Change Reward Token Amount Type from BigInt to String

## Changes
- Modified the reward token amount type from `bigint` to `string` across components and hooks
- Updated contract interaction to parse string amounts at the last possible moment

## Why
- Improves developer experience by handling token amounts as strings until the final contract interaction
- Prevents potential precision loss and makes it easier to work with decimal values
- Follows best practices for handling token amounts in DeFi applications

## Technical Details
- Changed `transferAmount` type from `bigint` to `string` in:
  - `ManageRewardToken` component props
  - `TokenManagement` component interface
  - `AddRewardTokenParams` interface in `useFreebaseAdmin` hook
- Modified `parseEther` call to accept string input directly instead of converting from BigInt

## Testing
- [ ] Verify reward token addition flow works with decimal inputs
- [ ] Confirm amount parsing works correctly for contract interactions
- [ ] Test allowance checks with new string-based amounts

Closes #300 